### PR TITLE
fix getting the root element in IE 11

### DIFF
--- a/src/FormattedXmlMessage.js
+++ b/src/FormattedXmlMessage.js
@@ -52,7 +52,7 @@ function FormattedXmlMessage(props: Props) {
 
   // we force XML (not html) so it's easier to parse (polyfills) and closer to JSX.
   const doc = getParser().parseFromString(xmlMessage, 'text/xml');
-  const root = doc.children[0];
+  const root = doc.firstChild;
 
   return (
     <Text>


### PR DESCRIPTION
in IE 11 the document returned from parseFromString() does not have property children.